### PR TITLE
CPI Portal Client failing

### DIFF
--- a/0-introduction/cbsp_hackathon.ipynb
+++ b/0-introduction/cbsp_hackathon.ipynb
@@ -109,7 +109,7 @@
     "from bravado.client import SwaggerClient\n",
     "\n",
     "cbioportal = SwaggerClient.from_url('https://www.cbioportal.org/api/api-docs',\n",
-    "                                config={\"validate_requests\":False,\"validate_responses\":False})\n",
+    "                                config={\"validate_requests\":False,\"validate_responses\":False,\"validate_swagger_spec\":False})\n",
     "print(cbioportal)"
    ]
   },


### PR DESCRIPTION
The validation is failing in the API tutorial. This is a fix to relax the API requirements.